### PR TITLE
Fix NameError for declarative_base

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,5 +1,6 @@
 from sqlalchemy import inspect
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.declarative import declarative_base
 import os
 
 # Attempt to import the configuration.


### PR DESCRIPTION
Import `declarative_base` from `sqlalchemy.ext.declarative` in `database.py` to resolve a NameError that was preventing the application from starting.